### PR TITLE
matched example stun.attributes to code stun.attribute

### DIFF
--- a/examples/client.js
+++ b/examples/client.js
@@ -28,7 +28,7 @@ client1.on('response', function(packet){
     console.log('Received STUN packet:', packet);
     
     // Save NAT Address
-    peer.push(packet.attrs[stun.attributes.MAPPED_ADDRESS]);
+    peer.push(packet.attrs[stun.attribute.MAPPED_ADDRESS]);
 
     // Sending STUN Packet
     client2.request(onRequest);
@@ -39,7 +39,7 @@ client2.on('response', function(packet){
     console.log('Received STUN packet:', packet);
 
     // Save NAT Address
-    peer.push(packet.attrs[stun.attributes.MAPPED_ADDRESS]);
+    peer.push(packet.attrs[stun.attribute.MAPPED_ADDRESS]);
 
     // Sending UDP message
     var msg = new Buffer("Hello!");


### PR DESCRIPTION
The example shows stun.attributes but based on https://github.com/summerwind/node-stun/blob/master/lib/index.js#L9 I think it should be stun.attribute.